### PR TITLE
Hotfix/obter filtro query

### DIFF
--- a/filtro/views.py
+++ b/filtro/views.py
@@ -47,14 +47,14 @@ def obter_filtro(idfiltro, username, responsavel=False):
     )
 
 
-def obter_filtros(username, responsavel=False):
-    if responsavel:
-        return Filtro.objects.filter(
-            Q(responsavel=username)
+def obter_filtros(username, only_responsavel=False):
+    qs = Filtro.objects.filter(responsavel=username)
+    if not only_responsavel:
+        qs = qs.union(
+            Filtro.objects.filter(usuarioacessofiltro__usuario=username)
         )
-    return Filtro.objects.filter(
-        (Q(responsavel=username) | Q(usuarioacessofiltro__usuario=username))
-    )
+
+    return qs
 
 
 def dictfetchall(cursor):

--- a/filtro/views.py
+++ b/filtro/views.py
@@ -52,14 +52,14 @@ def obter_filtro(idfiltro, username, responsavel=False):
     )
 
 
-def obter_filtros(username, only_responsavel=False):
-    qs = Filtro.objects.filter(responsavel=username)
-    if not only_responsavel:
-        qs = qs.union(
-            Filtro.objects.filter(usuarioacessofiltro__usuario=username)
+def obter_filtros(username, responsavel=False):
+    if responsavel:
+        return Filtro.objects.filter(
+            Q(responsavel=username)
         )
-
-    return qs
+    return Filtro.objects.filter(
+        (Q(responsavel=username) | Q(usuarioacessofiltro__usuario=username))
+    )
 
 
 def dictfetchall(cursor):

--- a/filtro/views.py
+++ b/filtro/views.py
@@ -8,7 +8,12 @@ from django.core.paginator import Paginator
 from django.db.models import Count
 from django.db import connection
 from django.utils.encoding import smart_str
-from django.http import JsonResponse, StreamingHttpResponse, HttpResponse, Http404
+from django.http import (
+    JsonResponse,
+    StreamingHttpResponse,
+    HttpResponse,
+    Http404
+)
 from wsgiref.util import FileWrapper
 from django.shortcuts import (
     render,

--- a/filtro/views.py
+++ b/filtro/views.py
@@ -54,12 +54,11 @@ def obter_filtro(idfiltro, username, responsavel=False):
 
 def obter_filtros(username, responsavel=False):
     if responsavel:
-        return Filtro.objects.filter(
-            Q(responsavel=username)
-        )
+        return Filtro.objects.filter(responsavel=username)
+
     return Filtro.objects.filter(
         (Q(responsavel=username) | Q(usuarioacessofiltro__usuario=username))
-    )
+    ).distinct()
 
 
 def dictfetchall(cursor):


### PR DESCRIPTION
A query da funcção `obter_filtros` estava caindo na pegadinha do `JOIN`

Como um filtro tinha sido compartilhado com N pessoas, o JOIN estava duplicando o result set N vezes

```sql
SELECT 
"filtro_filtro"."id",
"filtro_filtro"."nome",
"filtro_filtro"."tipo_raspador",
"filtro_filtro"."arquivo_documentos", 
"filtro_filtro"."situacao",
"filtro_filtro"."saida", 
"filtro_filtro"."saida_lda", 
"filtro_filtro"."responsavel", 
"filtro_filtro"."percentual_atual" 
FROM "filtro_filtro" 
LEFT OUTER JOIN "filtro_usuarioacessofiltro"    -- Aqui os registros eram duplicados
    ON ("filtro_filtro"."id" = "filtro_usuarioacessofiltro"."filtro_id") 
WHERE ("filtro_filtro"."responsavel" = <username> OR "filtro_usuarioacessofiltro"."usuario" = <username>) 
-- quando a cláusula WHERE era executada, too late, as tabelas já foram juntadas
```

Apliquei um `distinct`  para remover as linhas duplicadas